### PR TITLE
Count working days from Sunday bug

### DIFF
--- a/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
+++ b/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
@@ -287,6 +287,27 @@ namespace Mindbox.WorkingCalendar.Tests
 			Assert.AreEqual(expected, workingDays);
 		}
 
+		[DataRow(14, 0)]
+		[DataRow(15, 1)]
+		[DataRow(16, 2)]
+		[DataRow(17, 3)]
+		[DataRow(18, 4)]
+		[DataRow(19, 5)]
+		[DataRow(20, 5)]
+		[DataRow(21, 5)]
+		[DataRow(22, 6)]
+		[DataRow(29, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromSundayWithTime(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 13, 0, 0, 1);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
 		[DataRow(15, 1)]
 		[DataRow(16, 2)]
 		[DataRow(17, 3)]

--- a/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
+++ b/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
@@ -244,6 +244,28 @@ namespace Mindbox.WorkingCalendar.Tests
 			Assert.AreEqual(expected, workingDays);
 		}
 
+		[DataRow(13, 0)]
+		[DataRow(14, 0)]
+		[DataRow(15, 1)]
+		[DataRow(16, 2)]
+		[DataRow(17, 3)]
+		[DataRow(18, 4)]
+		[DataRow(19, 5)]
+		[DataRow(20, 5)]
+		[DataRow(21, 5)]
+		[DataRow(22, 6)]
+		[DataRow(29, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromSaturdayWithTime(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 12, 0, 0, 1);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
 		[DataRow(14, 0)]
 		[DataRow(15, 1)]
 		[DataRow(16, 2)]

--- a/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
+++ b/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
@@ -221,5 +221,154 @@ namespace Mindbox.WorkingCalendar.Tests
 			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
 			Assert.AreEqual(3, workingDays);
 		}
+
+		[DataRow(13, 0)]
+		[DataRow(14, 0)]
+		[DataRow(15, 1)]
+		[DataRow(16, 2)]
+		[DataRow(17, 3)]
+		[DataRow(18, 4)]
+		[DataRow(19, 5)]
+		[DataRow(20, 5)]
+		[DataRow(21, 5)]
+		[DataRow(22, 6)]
+		[DataRow(29, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromSaturday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 12);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+		[DataRow(14, 0)]
+		[DataRow(15, 1)]
+		[DataRow(16, 2)]
+		[DataRow(17, 3)]
+		[DataRow(18, 4)]
+		[DataRow(19, 5)]
+		[DataRow(20, 5)]
+		[DataRow(21, 5)]
+		[DataRow(22, 6)]
+		[DataRow(29, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromSunday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 13);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+		[DataRow(15, 1)]
+		[DataRow(16, 2)]
+		[DataRow(17, 3)]
+		[DataRow(18, 4)]
+		[DataRow(19, 5)]
+		[DataRow(20, 5)]
+		[DataRow(21, 5)]
+		[DataRow(22, 6)]
+		[DataRow(23, 7)]
+		[DataRow(29, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromMonday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 14);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+		[DataRow(16, 1)]
+		[DataRow(17, 2)]
+		[DataRow(18, 3)]
+		[DataRow(19, 4)]
+		[DataRow(20, 4)]
+		[DataRow(21, 4)]
+		[DataRow(22, 5)]
+		[DataRow(23, 6)]
+		[DataRow(24, 7)]
+		[DataRow(30, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromTuesday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 15);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+		[DataRow(17, 1)]
+		[DataRow(18, 2)]
+		[DataRow(19, 3)]
+		[DataRow(20, 3)]
+		[DataRow(21, 3)]
+		[DataRow(22, 4)]
+		[DataRow(23, 5)]
+		[DataRow(24, 6)]
+		[DataRow(25, 7)]
+		[DataRow(31, 11)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromWednesday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 16);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+
+		[DataRow(18, 1)]
+		[DataRow(19, 2)]
+		[DataRow(20, 2)]
+		[DataRow(21, 2)]
+		[DataRow(22, 3)]
+		[DataRow(23, 4)]
+		[DataRow(24, 5)]
+		[DataRow(25, 6)]
+		[DataRow(26, 7)]
+		[DataRow(31, 10)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromThursday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 17);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
+
+		[DataRow(19, 1)]
+		[DataRow(20, 1)]
+		[DataRow(21, 1)]
+		[DataRow(22, 2)]
+		[DataRow(23, 3)]
+		[DataRow(24, 4)]
+		[DataRow(25, 5)]
+		[DataRow(26, 6)]
+		[DataRow(27, 6)]
+		[DataRow(31, 9)]
+		[DataTestMethod]
+		public void CountWorkingDaysInPeriod_FromFriday(int endDay, int expected)
+		{
+			var calendar = new WorkingCalendar(new RussianWorkingDaysExceptionsProvider());
+			var startDateTime = new DateTime(2020, 12, 18);
+			var endDateTime = new DateTime(2020, 12, endDay);
+
+			var workingDays = calendar.CountWorkingDaysInPeriod(startDateTime, endDateTime);
+			Assert.AreEqual(expected, workingDays);
+		}
 	}
 }

--- a/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
+++ b/Mindbox.WorkingCalendar.Tests/CountWorkingDaysInPeriodTests.cs
@@ -328,7 +328,6 @@ namespace Mindbox.WorkingCalendar.Tests
 			Assert.AreEqual(expected, workingDays);
 		}
 
-
 		[DataRow(18, 1)]
 		[DataRow(19, 2)]
 		[DataRow(20, 2)]

--- a/Mindbox.WorkingCalendar/Mindbox.WorkingCalendar.csproj
+++ b/Mindbox.WorkingCalendar/Mindbox.WorkingCalendar.csproj
@@ -27,7 +27,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>Mindbox.WorkingCalendar</PackageId>
-		<PackageVersion>1.0.15</PackageVersion>
+		<PackageVersion>1.0.16</PackageVersion>
 		<Authors>Mindbox</Authors>
 		<Description>Helpers for counting working days and holidays. Includes working days exceptions for Russia.</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Mindbox.WorkingCalendar/WorkingCalendar.cs
+++ b/Mindbox.WorkingCalendar/WorkingCalendar.cs
@@ -86,8 +86,9 @@ namespace Mindbox.WorkingCalendar
 			var totalElapsedDays = (int) (endDateTimeRounded - startDateTimeRounded).TotalDays;
 			
 			var daysFromNearestMonday = dayOfWeekOffsets[startDateTimeRounded.DayOfWeek] + totalElapsedDays;
-			var weekendDays = (daysFromNearestMonday / 7) * 2 + (daysFromNearestMonday % 7 == 6 ? 1 : 0) -
-				(startDateTimeRounded.DayOfWeek == DayOfWeek.Sunday ? 1 : 0);
+			var weekendDays = (daysFromNearestMonday / 7) * 2
+				+ (daysFromNearestMonday % 7 == 6 ? 1 : 0)
+				- (startDateTimeRounded.DayOfWeek == DayOfWeek.Sunday ? 1 : 0);
 
 			var exceptionsInPeriod = exceptionsProvider.GetExceptionsInPeriod(startDateTimeRounded, endDateTimeRounded).ToArray();
 

--- a/Mindbox.WorkingCalendar/WorkingCalendar.cs
+++ b/Mindbox.WorkingCalendar/WorkingCalendar.cs
@@ -86,7 +86,8 @@ namespace Mindbox.WorkingCalendar
 			var totalElapsedDays = (int) (endDateTimeRounded - startDateTimeRounded).TotalDays;
 			
 			var daysFromNearestMonday = dayOfWeekOffsets[startDateTimeRounded.DayOfWeek] + totalElapsedDays;
-			var weekendDays = (daysFromNearestMonday / 7) * 2 + (daysFromNearestMonday % 7 == 6 ? 1 : 0);
+			var weekendDays = (daysFromNearestMonday / 7) * 2 + (daysFromNearestMonday % 7 == 6 ? 1 : 0) -
+				(startDateTimeRounded.DayOfWeek == DayOfWeek.Sunday ? 1 : 0);
 
 			var exceptionsInPeriod = exceptionsProvider.GetExceptionsInPeriod(startDateTimeRounded, endDateTimeRounded).ToArray();
 
@@ -109,8 +110,7 @@ namespace Mindbox.WorkingCalendar
 			}
 			totalElapsedDays += (int)dateParts.TotalDays;
 
-			return totalElapsedDays - weekendDays - nonWeekendHolidays + workingWeekendDays +
-				(startDateTimeRounded.DayOfWeek == DayOfWeek.Sunday ? 1 : 0);
+			return totalElapsedDays - weekendDays - nonWeekendHolidays + workingWeekendDays;
 		}
 
 		/// <summary>

--- a/Mindbox.WorkingCalendar/WorkingCalendar.cs
+++ b/Mindbox.WorkingCalendar/WorkingCalendar.cs
@@ -109,7 +109,8 @@ namespace Mindbox.WorkingCalendar
 			}
 			totalElapsedDays += (int)dateParts.TotalDays;
 
-			return totalElapsedDays - weekendDays - nonWeekendHolidays + workingWeekendDays;
+			return totalElapsedDays - weekendDays - nonWeekendHolidays + workingWeekendDays +
+				(startDateTimeRounded.DayOfWeek == DayOfWeek.Sunday ? 1 : 0);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Когда в качестве startDateTime задается любое время из промежутка от субботы со временем 00:00:01 до воскресенья 00:00:00 неправильно считаются рабочие дни. 
До понедельника результат будет: -1,
до вторника: 0,
до среды: 1 
и т.д.
Чтобы поправить возвращаемый результат внес в формулу тернарный оператор на проверку воскресенья. Лучшего решения найти не удалось.

Также добавил тесты.